### PR TITLE
Updated partitions to match working partitions from simulation

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -54,36 +54,27 @@ class PartitionStrategy(Enum):
 
 
 @dataclass
-class FixedPartitionStrategy:
-  '''
-  Defines the parameters for the FIXED partition strategy
-  '''
-  train_fixed_bounds: DatasetGeographicPartitions
-  validation_fixed_bounds: DatasetGeographicPartitions
-  test_fixed_bounds: DatasetGeographicPartitions
-
-
 _FIXED_PARTITION_STRATEGY = FixedPartitionStrategy(
   # Train
   DatasetGeographicPartitions(
-    min_longitude=-62.5,
-    max_longitude=float('inf'),
-    min_latitude=-5,
+    min_longitude=float('-inf'),
+    max_longitude=-58,
+    min_latitude=float('-inf'),
     max_latitude=float('inf'),
   ),
   # Validation
   DatasetGeographicPartitions(
-    min_longitude=float('-inf'),
-    max_longitude=-62.5,
-    min_latitude=-5,
-    max_latitude=float('inf')
+    min_longitude=-58,
+    max_longitude=float('inf'),
+    min_latitude=float('-inf'),
+    max_latitude=-3.9923
   ),
   # Test
   DatasetGeographicPartitions(
-    min_longitude=float('-inf'),
+    min_longitude=-58,
     max_longitude=float('inf'),
-    min_latitude=float('-inf'),
-    max_latitude=-5
+    min_latitude=-3.9923,
+    max_latitude=float('inf')
   )
 )
 

--- a/partitioned_dataset.py
+++ b/partitioned_dataset.py
@@ -51,26 +51,27 @@ class FixedPartitionStrategy:
 _FIXED_PARTITION_STRATEGY = FixedPartitionStrategy(
   # Train
   DatasetGeographicPartitions(
-    min_longitude=-62.5,
-    max_longitude=float('inf'),
-    min_latitude=-5,
+    min_longitude=float('-inf'),
+    max_longitude=-58,
+    min_latitude=float('-inf'),
     max_latitude=float('inf'),
   ),
   # Validation
   DatasetGeographicPartitions(
-    min_longitude=float('-inf'),
-    max_longitude=-62.5,
-    min_latitude=-5,
-    max_latitude=float('inf')
+    min_longitude=-58,
+    max_longitude=float('inf'),
+    min_latitude=float('-inf'),
+    max_latitude=-3.9923
   ),
   # Test
   DatasetGeographicPartitions(
-    min_longitude=float('-inf'),
+    min_longitude=-58,
     max_longitude=float('inf'),
-    min_latitude=float('-inf'),
-    max_latitude=-5
+    min_latitude=-3.9923,
+    max_latitude=float('inf')
   )
 )
+
 
 @dataclass
 class RandomPartitionStrategy:


### PR DESCRIPTION
Update partitions to match the working partitions from the simulation (original coordinates were eyeballed to match plot of sample sites-- updated coordinates match real points in the corresponding real dataset):

![image](https://github.com/tnc-br/ddf_common/assets/4665783/693989e3-e263-47e9-a47e-a4b706117ec2)

Trained on real data with default variational inference (updated defaults in additional PR):
Val loss: 1.397790789604187
Train loss: 0.9393936395645142
Test loss: 0.9468271732330322
dO18 RMSE: 0.9135236042418461
