### PR TITLE
Added code to provide the option to mount and use Google Drive

### DIFF
--- a/generate_isoscape.ipynb
+++ b/generate_isoscape.ipynb
@@ -3,16 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/amazon_only/generate_isoscape.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "muxw0qAviP5M"
       },
       "source": [
@@ -21,7 +11,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "Z411bUWuVAfG"
       },
@@ -30,11 +20,17 @@
         "MODEL_SAVE_LOCATION = \"/content/gdrive/MyDrive/amazon_rainforest_files/variational/model/random_boosted_isorix_carbon_ensemble.tf\" #@param\n",
         "TRANSFORMER_SAVE_LOCATION = \"/content/gdrive/MyDrive/amazon_rainforest_files/variational/model/random_boosted_isorix_carbon_ensemble.pkl\" #@param\n",
         "OUTPUT_RASTER_NAME = \"amazon_test_old_res\" #@param\n",
+        "USE_LOCAL_DRIVE = False #@param {type:\"boolean\"}\n",
         "\n",
         "# Number of pixels on each dimension\n",
         "RESOLUTION_X = 300 #@param\n",
         "RESOLUTION_Y = 300 #@param\n",
-        "AMAZON_ONLY = False #@param {type: \"boolean\"}"
+        "AMAZON_ONLY = False #@param {type: \"boolean\"}\n",
+        "\n",
+        "# Access data stored on Google Drive if not reading data locally.\n",
+        "if not USE_LOCAL_DRIVE:\n",
+        "  from google.colab import drive\n",
+        "  drive.mount('/content/gdrive')"
       ]
     },
     {
@@ -84,7 +80,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "36Aeo8B5bVOl"
       },
@@ -172,8 +168,7 @@
   "metadata": {
     "colab": {
       "machine_shape": "hm",
-      "provenance": [],
-      "include_colab_link": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/generate_isoscape.ipynb
+++ b/generate_isoscape.ipynb
@@ -25,12 +25,7 @@
         "# Number of pixels on each dimension\n",
         "RESOLUTION_X = 300 #@param\n",
         "RESOLUTION_Y = 300 #@param\n",
-        "AMAZON_ONLY = False #@param {type: \"boolean\"}\n",
-        "\n",
-        "# Access data stored on Google Drive if not reading data locally.\n",
-        "if not USE_LOCAL_DRIVE:\n",
-        "  from google.colab import drive\n",
-        "  drive.mount('/content/gdrive')"
+        "AMAZON_ONLY = False #@param {type: \"boolean\"}"
       ]
     },
     {
@@ -59,15 +54,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "M82e_JJJPIds"
-      },
-      "outputs": [],
       "source": [
         "import model\n",
-        "import raster"
-      ]
+        "import raster\n",
+        "\n",
+        "# Access data stored on Google Drive if not reading data locally.\n",
+        "if not USE_LOCAL_DRIVE:\n",
+        "  raster.mount_gdrive()"
+      ],
+      "metadata": {
+        "id": "LUhJ2C1QS5Pz"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Currently, the isoscape generation notebook includes an example that references files on Google Drive, but it does not provide functionality to mount Google Drive. Users who attempt to run the notebook in its current state will not experience working behavior out of the box.

This PR makes a minimal change to enable loading files from Google Drive unless a checkbox override (USE_LOCAL_DRIVE) is ticked in the Colab UI, consistent with our other Colabs like data ingestion and variational inference.

Merging this PR would bring the behavior of the isoscape generation notebook in line with the others that we cover in our guide docs-- data_ingestion and variational_inference.