### PR TITLE
Update generate_isoscape notebook to use updated function signature

### DIFF
--- a/generate_isoscape.ipynb
+++ b/generate_isoscape.ipynb
@@ -11,7 +11,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "Z411bUWuVAfG"
       },
@@ -30,11 +30,32 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
-        "id": "t2Lwa0v2UPjB"
+        "id": "t2Lwa0v2UPjB",
+        "outputId": "7ca67daf-c2af-4fe0-faa0-46c2afbae94c",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'ddf_common_stub'...\n",
+            "remote: Enumerating objects: 14, done.\u001b[K\n",
+            "remote: Counting objects: 100% (14/14), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (14/14), done.\u001b[K\n",
+            "remote: Total 14 (delta 5), reused 0 (delta 0), pack-reused 0\u001b[K\n",
+            "Receiving objects: 100% (14/14), 6.14 KiB | 6.14 MiB/s, done.\n",
+            "Resolving deltas: 100% (5/5), done.\n",
+            "executing checkout_branch ...\n",
+            "b''\n",
+            "main branch checked out as readonly. You may now use ddf_common imports\n"
+          ]
+        }
+      ],
       "source": [
         "#@title Imports and modules.\n",
         "\n",
@@ -63,10 +84,22 @@
         "  raster.mount_gdrive()"
       ],
       "metadata": {
-        "id": "LUhJ2C1QS5Pz"
+        "id": "LUhJ2C1QS5Pz",
+        "outputId": "58ae661d-e646-4e76-92c3-21361baea729",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Mounted at /content/gdrive\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -79,37 +112,61 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "id": "36Aeo8B5bVOl"
       },
       "outputs": [],
       "source": [
-        "vi_model = model.TFModel(MODEL_SAVE_LOCATION, TRANSFORMER_SAVE_LOCATION)\n",
-        "\n",
-        "# Note: These need to be in the same as the columns used to train the model.\n",
-        "required_geotiffs = [\n",
-        "    'VPD', 'RH', 'PET', 'DEM', 'PA',\n",
-        "    'Mean Annual Temperature','Mean Annual Precipitation',\n",
-        "    'Iso_Oxi_Stack_mean_TERZER',\n",
-        "    'isoscape_fullmodel_d18O_prec_REGRESSION',\n",
-        "    'brisoscape_mean_ISORIX',\n",
-        "    'd13C_cel_mean',\n",
-        "    'd13C_cel_var',\n",
-        "    'ordinary_kriging_linear_d18O_predicted_mean',\n",
-        "    'ordinary_kriging_linear_d18O_predicted_variance']"
+        "vi_model = model.TFModel(MODEL_SAVE_LOCATION, TRANSFORMER_SAVE_LOCATION)"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "nLwdaqCq1rLl"
+        "id": "nLwdaqCq1rLl",
+        "outputId": "827b031a-3aa7-451b-d12f-7af6a2a4d220",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 941 x 937 x 12\n",
+            "Projection is GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]\n",
+            "Origin = (-74.0000000000241, 5.29166666665704)\n",
+            "Pixel Size = (0.04166666666665718, -0.04166666666667143)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 941 x 937 x 12\n",
+            "Projection is GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]\n",
+            "Origin = (-74.0000000000241, 5.29166666665704)\n",
+            "Pixel Size = (0.04166666666665718, -0.04166666666667143)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 942 x 936 x 1\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-74.0, 5.25)\n",
+            "Pixel Size = (0.041666666666666664, -0.041666666666666664)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 5418 x 4683 x 2\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-73.991666667, 5.275)\n",
+            "Pixel Size = (0.008333333333333335, -0.008333333333333333)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 5418 x 4683 x 2\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-73.991666667, 5.275)\n",
+            "Pixel Size = (0.008333333333333335, -0.008333333333333333)\n"
+          ]
+        }
+      ],
       "source": [
         "raster.generate_isoscapes_from_variational_model(\n",
-        "  vi_model, required_geotiffs, RESOLUTION_X, RESOLUTION_Y, OUTPUT_RASTER_NAME, amazon_only=AMAZON_ONLY)"
+        "  vi_model, RESOLUTION_X, RESOLUTION_Y, OUTPUT_RASTER_NAME, amazon_only=AMAZON_ONLY)"
       ]
     },
     {


### PR DESCRIPTION
This makes generating isoscapes agnostic of column training order.