### PR TITLE
Move generation isoscape functions to new file; implement dispatch_rasters

### DIFF
--- a/eeddf.py
+++ b/eeddf.py
@@ -3,11 +3,13 @@ import pandas as pd
 import dataset
 import raster
 import eeraster
+import generate_isoscape
 import importlib
 
 importlib.reload(dataset)
 importlib.reload(raster)
 importlib.reload(eeraster)
+importlib.reload(generate_isoscape)
 
 from dataset import load_reference_samples
 from eeraster import eeRaster

--- a/eeraster.py
+++ b/eeraster.py
@@ -281,5 +281,9 @@ def dem():
       'projects/sat-io/open-datasets/GLO-30').select("b1"))
   return _dem
 
-
+# A collection of column names to functions that load the corresponding 
+# earth engine asset.
+column_name_to_ee_asset_fn = {
+  "DEM": dem,
+}
 

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -39,8 +39,6 @@ def save_numpy_to_geotiff(bounds: raster.Bounds, prediction: np.ma.MaskedArray, 
 def check_same_order(expected: typing.List[str], actual: typing.List[str]):
   actual.remove("lat")
   actual.remove("long")
-  print(actual)
-  print(expected)
   if (expected != actual):
     raise ValueError("Geotiff inputs don't match the inputs expected by the model")
 

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -130,7 +130,7 @@ def dispatch_rasters(
       if raster_name in rasters_to_dispatch:
         continue
       
-      # Load it from local (or gdrive) storage to memory.
+      # Load it from local (or gdrive).
       if raster_name in raster.column_name_to_geotiff_fn:
         rasters_to_dispatch[raster_name] = raster.column_name_to_geotiff_fn[raster_name]()
 
@@ -178,7 +178,7 @@ def generate_isoscapes_from_variational_model(
     use_earth_engine_assets=True,
     local_fallback=True)
 
-  arbitrary_geotiff = list(input_geotiffs.values())[0]  
+  arbitrary_geotiff = raster.dem_geotiff()
   if amazon_only:
     arbitrary_geotiff = raster.d13C_mean_amazon_only_geotiff()
   base_bounds = raster.get_extent(arbitrary_geotiff.gdal_dataset)

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -190,7 +190,7 @@ def generate_isoscapes_from_variational_model(
     use_earth_engine_assets=True,
     local_fallback=True)
 
-  arbitrary_geotiff = raster.dem_geotiff()
+  arbitrary_geotiff = raster.vapor_pressure_deficit_geotiff()
   if amazon_only:
     arbitrary_geotiff = raster.d13C_mean_amazon_only_geotiff()
   base_bounds = raster.get_extent(arbitrary_geotiff.gdal_dataset)

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -52,6 +52,9 @@ def get_predictions_at_each_pixel(
   `bounds`: Every pixel within these bounds will have a prediction made on it
   `geometry_mask`: If specified, only make predictions within this mask and within `bounds`."""
 
+  if geotiffs.keys() + ['lat', 'long'] != model.training_column_names():
+    raise ValueError("Geotiff inputs don't match the inputs expected by the model")
+
   # Initialize a blank plane representing means and variance.
   predicted_np = np.ma.array(
       np.zeros([bounds.raster_size_x, bounds.raster_size_y, 2], dtype=float),

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -1,0 +1,185 @@
+import raster
+import eeraster
+import typing
+
+def save_numpy_to_geotiff(bounds: Bounds, prediction: np.ma.MaskedArray, path: str):
+  """Copy metadata from a base geotiff and write raster data + mask from `data`"""
+  driver = gdal.GetDriverByName("GTiff")
+  metadata = driver.GetMetadata()
+  if metadata.get(gdal.DCAP_CREATE) != "YES":
+      raise RuntimeError("GTiff driver does not support required method Create().")
+  if metadata.get(gdal.DCAP_CREATECOPY) != "YES":
+      raise RuntimeError("GTiff driver does not support required method CreateCopy().")
+
+  dataset = driver.Create(path, bounds.raster_size_x, bounds.raster_size_y, prediction.shape[2], eType=gdal.GDT_Float64)
+  dataset.SetGeoTransform([bounds.minx, bounds.pixel_size_x, 0, bounds.maxy, 0, bounds.pixel_size_y])
+  dataset.SetProjection('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4326"]]')
+
+  if len(prediction.shape) != 3 or prediction.shape[0] != bounds.raster_size_x or prediction.shape[1] != bounds.raster_size_y:
+    raise ValueError("Shape of prediction does not match base geotiff")
+  
+  prediction_transformed = np.flip(np.transpose(prediction, axes=[1,0,2]), axis=0)
+  for band_index in range(dataset.RasterCount):
+    band = dataset.GetRasterBand(band_index+1)
+    if band.CreateMaskBand(0) == gdal.CE_Failure:
+      raise RuntimeError("Failed to create mask band")
+    mask_band = band.GetMaskBand()
+    band.WriteArray(np.choose(prediction_transformed[:, :, band_index].mask, (prediction_transformed[:, :, band_index].data,np.array(band.GetNoDataValue()),)))
+    mask_band.WriteArray(np.logical_not(prediction_transformed[:, :, band_index].mask))
+
+def get_predictions_at_each_pixel(
+    model: model.Model,
+    geotiffs: dict[str, AmazonGeoTiff],
+    bounds: Bounds,
+    geometry_mask: AmazonGeoTiff=None):
+  """Uses `model` to make mean/variance predictions for every pixel in `bounds`.
+  Queries are constructed by querying every geotiff in `geotiffs` for information 
+  at that pixel and passing the parameters to the model. 
+  
+  Parameters are standardized using feature_transformer, a set of standardizers used
+  to fit training data.
+  
+  `model`: Tensorflow model used to make predictions
+  `feature_transformer`: ScikitLearn ColumnTransformer storing transformations of columns
+                         Input must be transformed prior to predictions
+  `geotiffs`: The set of geotiffs required to make the prediction
+  `bounds`: Every pixel within these bounds will have a prediction made on it
+  `geometry_mask`: If specified, only make predictions within this mask and within `bounds`."""
+
+  # Initialize a blank plane representing means and variance.
+  predicted_np = np.ma.array(
+      np.zeros([bounds.raster_size_x, bounds.raster_size_y, 2], dtype=float),
+      mask=np.ones([bounds.raster_size_x, bounds.raster_size_y, 2], dtype=bool))
+
+  for x_idx, x in enumerate(tqdm(np.arange(bounds.minx, bounds.maxx, bounds.pixel_size_x, dtype=float))):
+    rows = []
+    row_indexes = []
+    for y_idx, y in enumerate(np.arange(bounds.miny, bounds.maxy, -bounds.pixel_size_y, dtype=float)):
+      # Row should contain all the features needed to predict, in the same
+      # column order the model was trained.
+      row = {}
+      row["lat"] = y
+      row["long"] = x
+
+      # Surround in try/except as we will be trying to fetch out of bounds data.
+      try:
+        if geometry_mask and pd.isnull(geometry_mask.value_at(x, y)):
+          continue
+        for geotiff_label, geotiff in geotiffs.items():
+          row[geotiff_label] = geotiff.value_at(x, y)
+          if pd.isnull(row[geotiff_label]):
+            raise ValueError
+      except (ValueError, IndexError):
+        continue # masked and out-of-bounds coordinates
+
+      rows.append(row)
+      row_indexes.append((y_idx,0,))
+
+    if (len(rows) > 0):
+      X = pd.DataFrame.from_dict(rows)
+      predictions = model.predict_on_batch(X)
+
+      means_np = predictions[:, 0]
+      for prediction, (y_idx, month_idx) in zip(means_np, row_indexes):
+        predicted_np.mask[x_idx,y_idx,0] = False # unmask since we have data
+        predicted_np.data[x_idx,y_idx,0] = prediction
+      vars_np = predictions[:, 1]
+      for prediction, (y_idx, month_idx) in zip (vars_np, row_indexes):
+        predicted_np.mask[x_idx, y_idx, 1] = False
+        predicted_np.data[x_idx, y_idx, 1] = prediction
+
+  return predicted_np
+
+def dispatch_rasters(
+    required_rasters: typing.List[str],
+    use_earth_engine_assets : bool=False,
+    local_fallback: bool=False):
+  """
+  dispatch_rasters function
+  --------------------------------------------------
+  Loads rasters either from Google Earth Engine or from a local/gdrive
+  depending on parameters
+  --------------------------------------------------
+  Parameters:
+  required_rasters:
+    The list of rasters to load, e.g. ["DEM", "PA", "VPD"]
+  use_earth_engine_assets: 
+    Whether to load the rasters from earth engine. If False, loads from local/gdrive.
+  local_fallback:
+    If use_earth_engine_assets=True, whether to fallback to gdrive if rasters could not
+    be found in ee. 
+  """
+
+  rasters_to_dispatch = {}
+
+  if use_earth_engine_assets:
+    for raster in required_rasters:
+      if raster in eeraster.column_name_to_ee_asset_fn:
+        rasters_to_dispatch[raster] = eeraster.column_name_to_ee_asset_fn[raster]()
+
+  if not use_earth_engine_assets or local_fallback:
+    for raster in required_rasters:
+      
+      # Skip loading locally if it was found in EE.
+      if raster in rasters_to_dispatch:
+        continue
+      
+      # Load it from local (or gdrive) storage to memory.
+      if raster in raster.column_name_to_geotiff_fn:
+        rasters_to_dispatch[raster] = raster.column_name_to_geotiff_fn[raster]()
+
+  # Identify missing rasters.
+  missing = set(rasters_to_dispatch.keys()) -  set(required_rasters)
+  if missing:
+    raise ValueError("The following training columns do not have an associated raster: ", missing)
+
+  return rasters_to_dispatch
+
+  
+
+def generate_isoscapes_from_variational_model(
+    model: model.Model,
+    res_x: int, 
+    res_y: int,
+    output_geotiff: str,
+    amazon_only: bool=False):
+  """
+  generate_isoscapes_from_variational_model function
+  --------------------------------------------------
+  This function generates an isoscape using a model, according
+  to the resolution specs. It queries the model for every 
+  pixel in a (res_x x res_y) tiff of the landscape.
+  --------------------------------------------------
+  Parameters:
+  model: model.Model 
+    Pretrained model used to make predictions on every pixel.
+  res_x: int
+    The output x resolution
+  res_y: int
+    The output y resolution
+  output_geotiff: str
+    Name of the file to output. 
+  amazon_only: bool
+    Whether to only generate a raster of the Amazon region as opposed to
+    all of Brazil.
+  """
+  required_geotiffs = model.training_column_names()
+  required_geotiffs.remove('lat')
+  required_geotiffs.remove('long')
+  
+  input_geotiffs = dispatch_rasters(
+    required_geotiffs,
+    use_earth_engine_assets=True,
+    local_fallback=True)
+
+  arbitrary_geotiff = list(input_geotiffs.values())[0]  
+  if amazon_only:
+    arbitrary_geotiff = d13C_mean_amazon_only_geotiff()
+  base_bounds = get_extent(arbitrary_geotiff.gdal_dataset)
+  output_resolution = create_bounds_from_res(res_x, res_y, base_bounds) 
+
+  np = get_predictions_at_each_pixel(
+    model, input_geotiffs, output_resolution, 
+    geometry_mask=arbitrary_geotiff)
+  save_numpy_to_geotiff(
+      output_resolution, np, get_raster_path(output_geotiff+".tiff"))

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -142,10 +142,10 @@ def dispatch_rasters(
     if use_earth_engine_assets:
       if feature in eeraster.column_name_to_ee_asset_fn:
         rasters_to_dispatch[feature] = eeraster.column_name_to_ee_asset_fn[feature]()
-      elif not use_earth_engine_assets or local_fallback:
-        if feature in raster.column_name_to_geotiff_fn:
-          rasters_to_dispatch[feature] = raster.column_name_to_geotiff_fn[feature]()
-          check_proj(rasters_to_dispatch[feature])
+    elif not use_earth_engine_assets or local_fallback:
+      if feature in raster.column_name_to_geotiff_fn:
+        rasters_to_dispatch[feature] = raster.column_name_to_geotiff_fn[feature]()
+        check_proj(rasters_to_dispatch[feature])
 
   # Identify missing rasters.
   missing = set(rasters_to_dispatch.keys()) -  set(required_rasters)

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -137,15 +137,14 @@ def dispatch_rasters(
             f"Please reproject to WGS 84 instead{_ENDC}")
 
   rasters_to_dispatch = {}
-
-  for feature in required_rasters:
-    if use_earth_engine_assets:
-      if feature in eeraster.column_name_to_ee_asset_fn:
-        rasters_to_dispatch[feature] = eeraster.column_name_to_ee_asset_fn[feature]()
+  for raster_name in required_rasters:
+    if use_earth_engine_assets and \
+       raster_name in eeraster.column_name_to_ee_asset_fn:
+        rasters_to_dispatch[raster_name] = eeraster.column_name_to_ee_asset_fn[raster_name]()
     elif not use_earth_engine_assets or local_fallback:
-      if feature in raster.column_name_to_geotiff_fn:
-        rasters_to_dispatch[feature] = raster.column_name_to_geotiff_fn[feature]()
-        check_proj(rasters_to_dispatch[feature])
+      if raster_name in raster.column_name_to_geotiff_fn:
+        rasters_to_dispatch[raster_name] = raster.column_name_to_geotiff_fn[raster_name]()
+        check_proj(rasters_to_dispatch[raster_name])
 
   # Identify missing rasters.
   missing = set(rasters_to_dispatch.keys()) -  set(required_rasters)

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -184,8 +184,8 @@ def generate_isoscapes_from_variational_model(
   base_bounds = raster.get_extent(arbitrary_geotiff.gdal_dataset)
   output_resolution = raster.create_bounds_from_res(res_x, res_y, base_bounds) 
 
-  np = get_predictions_at_each_pixel(
+  preds = get_predictions_at_each_pixel(
     model, input_geotiffs, output_resolution, 
     geometry_mask=arbitrary_geotiff)
   save_numpy_to_geotiff(
-      output_resolution, np, raster.get_raster_path(output_geotiff+".tiff"))
+      output_resolution, preds, raster.get_raster_path(output_geotiff+".tiff"))

--- a/generate_isoscape.py
+++ b/generate_isoscape.py
@@ -5,7 +5,7 @@ import eeraster
 import typing
 import numpy as np
 import pandas as pd
-from osgeo import gdal, gdal_array
+from osgeo import gdal, gdal_array, osr
 from tqdm import tqdm
 
 def save_numpy_to_geotiff(bounds: raster.Bounds, prediction: np.ma.MaskedArray, path: str):
@@ -134,6 +134,12 @@ def dispatch_rasters(
       # Load it from local (or gdrive).
       if raster_name in raster.column_name_to_geotiff_fn:
         rasters_to_dispatch[raster_name] = raster.column_name_to_geotiff_fn[raster_name]()
+        
+        projection = rasters_to_dispatch[raster_name].gdal_dataset.GetProjection()
+        geogcs = osr.SpatialReference(wkt=projection).GetAttrValue('geogcs')
+        if geogcs != 'WGS 84':
+          print("WARNING: {} projections will soon no longer be supported. "
+                "Please reproject to WGS 84 instead".format(geogcs))
 
   # Identify missing rasters.
   missing = set(rasters_to_dispatch.keys()) -  set(required_rasters)

--- a/raster_test.ipynb
+++ b/raster_test.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/det/raster_test.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -14,8 +14,6 @@
       "cell_type": "code",
       "execution_count": 10,
       "metadata": {
-        "id": "7Ej4_QMnD-u_",
-        "outputId": "65d9cff0-0556-4096-e56b-de01b497bb6d",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 631,
@@ -44,12 +42,14 @@
             "9e35289d99c242a19a7a97c65ff8a2cd",
             "a494def49c2e48a5be9f661f93f02876"
           ]
-        }
+        },
+        "id": "7Ej4_QMnD-u_",
+        "outputId": "65d9cff0-0556-4096-e56b-de01b497bb6d"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Requirement already satisfied: opencv-python in /usr/local/lib/python3.10/dist-packages (4.8.0.76)\n",
             "Requirement already satisfied: numpy>=1.21.2 in /usr/local/lib/python3.10/dist-packages (from opencv-python) (1.23.5)\n",
@@ -72,18 +72,18 @@
           ]
         },
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "6eaa780782d64d4dbfe9ba4bb5b53de4",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "interactive(children=(Text(value='', description='Email', placeholder='Enter email'), Text(value='', descripti…"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "6eaa780782d64d4dbfe9ba4bb5b53de4"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
       ],
       "source": [
@@ -131,10 +131,12 @@
         "import model\n",
         "import raster\n",
         "import pytest\n",
+        "import generate_isoscape as gen\n",
         "import importlib\n",
         "\n",
         "importlib.reload(model)\n",
         "importlib.reload(raster)\n",
+        "importlib.reload(gen)\n",
         "\n",
         "def fake_brazil_bounds():\n",
         "  return raster.Bounds(minx=-73.97513931345594,\n",
@@ -183,7 +185,7 @@
         "\n",
         "  run_id = 'raster_unit_test'\n",
         "\n",
-        "  raster.generate_isoscapes_from_variational_model(vi_model, res_x=235, res_y=235, output_geotiff=run_id)\n",
+        "  gen.generate_isoscapes_from_variational_model(vi_model, res_x=235, res_y=235, output_geotiff=run_id)\n",
         "\n",
         "  generated_means_raster = raster.load_raster(raster.get_raster_path(run_id+\".tiff\"), use_only_band_index=0)\n",
         "  assert 25.29 == pytest.approx(generated_means_raster.value_at(-59, -2.5), 0.01)\n",
@@ -206,7 +208,7 @@
         "\n",
         "  run_id = 'raster_unit_test_amazon_only'\n",
         "\n",
-        "  raster.generate_isoscapes_from_variational_model(vi_model, res_x=180, res_y=100, output_geotiff=run_id, amazon_only=True)\n",
+        "  gen.generate_isoscapes_from_variational_model(vi_model, res_x=180, res_y=100, output_geotiff=run_id, amazon_only=True)\n",
         "\n",
         "  generated_means_raster = raster.load_raster(raster.get_raster_path(run_id+\".tiff\"), use_only_band_index=0)\n",
         "  assert 25.29 == pytest.approx(generated_means_raster.value_at(-59, -2.5), 0.01)\n",
@@ -252,97 +254,97 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "#Stamp isoscape"
-      ],
       "metadata": {
         "id": "YBsPvC_g8cZ2"
-      }
+      },
+      "source": [
+        "#Stamp isoscape"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "filename = \"/content/gdrive/Shared drives/TNC Fellowship 🌳/4. Isotope Research & Signals/code/amazon_rainforest_files/amazon_rasters/variational/ensemble_with_carbon_brisoisorix/fixed_isorix_carbon_ensemble.tiff\" #@param"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "ehHGHgEi8bDW"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "filename = \"/content/gdrive/Shared drives/TNC Fellowship 🌳/4. Isotope Research & Signals/code/amazon_rainforest_files/amazon_rasters/variational/ensemble_with_carbon_brisoisorix/fixed_isorix_carbon_ensemble.tiff\" #@param"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "raster.show_stamps(filename)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "TXtyvU8b9odb"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "raster.show_stamps(filename)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bcdgVRzn9b-L"
+      },
+      "outputs": [],
       "source": [
         "metadata_name = \"TEST\"\n",
         "metadata_value = 0.55\n",
         "raster.stamp_isoscape(filename, metadata_name, metadata_value)"
-      ],
-      "metadata": {
-        "id": "bcdgVRzn9b-L"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "raster.show_stamps(filename)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "zTpgGXCN94u_"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "raster.show_stamps(filename)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "metadata_name = \"TEST\""
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "2vPrjn8X9_ZE"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "metadata_name = \"TEST\""
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "raster.del_stamp(filename, metadata_name)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "Qh2x5c1r9cR_"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "raster.del_stamp(filename, metadata_name)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "raster.show_stamps(filename)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "Rg6rvKaA-Fo0"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "raster.show_stamps(filename)"
+      ]
     }
   ],
   "metadata": {
     "colab": {
-      "provenance": [],
-      "include_colab_link": true
+      "include_colab_link": true,
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -353,407 +355,10 @@
     },
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {
-        "6eaa780782d64d4dbfe9ba4bb5b53de4": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "VBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [
-              "widget-interact"
-            ],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "VBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "VBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_d689561e25ec4820bca22967363c2c9e",
-              "IPY_MODEL_5f4c433c39464ab996666c8fe41989df",
-              "IPY_MODEL_56755712d78b4e638af4e2f9729db622",
-              "IPY_MODEL_a481d46f789d4e1aa802b7461afa1114"
-            ],
-            "layout": "IPY_MODEL_a6ce23727bff4334be37cd86fa8acccd"
-          }
-        },
-        "d689561e25ec4820bca22967363c2c9e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "TextModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "TextModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "TextView",
-            "continuous_update": true,
-            "description": "Email",
-            "description_tooltip": null,
-            "disabled": false,
-            "layout": "IPY_MODEL_1ce9a66df89441ad9e1fa31ac3c2cfaf",
-            "placeholder": "Enter email",
-            "style": "IPY_MODEL_f6bdb0823b9743ad8b38d049629d390c",
-            "value": "tripiace@yahoo.com"
-          }
-        },
-        "5f4c433c39464ab996666c8fe41989df": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "TextModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "TextModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "TextView",
-            "continuous_update": true,
-            "description": "Branch name",
-            "description_tooltip": null,
-            "disabled": false,
-            "layout": "IPY_MODEL_263ad9840616460aa4f070b0586c5dee",
-            "placeholder": "Enter branch name",
-            "style": "IPY_MODEL_7793937dec9344919ae716c9d87ae5a7",
-            "value": "det"
-          }
-        },
-        "56755712d78b4e638af4e2f9729db622": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ButtonModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ButtonModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ButtonView",
-            "button_style": "",
-            "description": "Checkout Code",
-            "disabled": false,
-            "icon": "",
-            "layout": "IPY_MODEL_0e44d4863dea488d9b1bb4c55f0b31e0",
-            "style": "IPY_MODEL_7a150d899e224e0fabcf4566a17615c3",
-            "tooltip": ""
-          }
-        },
-        "a481d46f789d4e1aa802b7461afa1114": {
-          "model_module": "@jupyter-widgets/output",
-          "model_name": "OutputModel",
-          "model_module_version": "1.0.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/output",
-            "_model_module_version": "1.0.0",
-            "_model_name": "OutputModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/output",
-            "_view_module_version": "1.0.0",
-            "_view_name": "OutputView",
-            "layout": "IPY_MODEL_4381c6b7e415413c8660cb49b2032ae5",
-            "msg_id": "",
-            "outputs": [
-              {
-                "output_type": "stream",
-                "name": "stdout",
-                "text": [
-                  "executing checkout_branch det...\n",
-                  "Branch det already checked out.\n",
-                  "Remember to reload your imports with `importlib.reload(module)`.\n",
-                  "b\"fatal: destination path 'ddf_common' already exists and is not an empty directory.\\nRepository already exists.\\n\"\n"
-                ]
-              },
-              {
-                "output_type": "stream",
-                "name": "stdout",
-                "text": [
-                  "b'From https://github.com/tnc-br/ddf_common\\n   6669160..533fd47  det        -> origin/det\\nUpdating 6669160..533fd47\\nFast-forward\\n model.py | 2 +-\\n 1 file changed, 1 insertion(+), 1 deletion(-)\\n'\n",
-                  "b''\n",
-                  "det branch checked out at \"/content/gdrive/MyDrive/det/ddf_common\". You may now use ddf_common imports and change common files.\n"
-                ]
-              },
-              {
-                "output_type": "display_data",
-                "data": {
-                  "text/plain": "interactive(children=(Text(value='required', description='Commit Msg', placeholder='Enter commit message'), Bu…",
-                  "application/vnd.jupyter.widget-view+json": {
-                    "version_major": 2,
-                    "version_minor": 0,
-                    "model_id": "15e0e911376547d892fc4677f5c4eb73"
-                  }
-                },
-                "metadata": {}
-              }
-            ]
-          }
-        },
-        "a6ce23727bff4334be37cd86fa8acccd": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "1ce9a66df89441ad9e1fa31ac3c2cfaf": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f6bdb0823b9743ad8b38d049629d390c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "263ad9840616460aa4f070b0586c5dee": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "7793937dec9344919ae716c9d87ae5a7": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
         "0e44d4863dea488d9b1bb4c55f0b31e0": {
           "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "7a150d899e224e0fabcf4566a17615c3": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ButtonStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ButtonStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "button_color": null,
-            "font_weight": ""
-          }
-        },
-        "4381c6b7e415413c8660cb49b2032ae5": {
-          "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
           "state": {
             "_model_module": "@jupyter-widgets/base",
             "_model_module_version": "1.2.0",
@@ -804,8 +409,8 @@
         },
         "15e0e911376547d892fc4677f5c4eb73": {
           "model_module": "@jupyter-widgets/controls",
-          "model_name": "VBoxModel",
           "model_module_version": "1.5.0",
+          "model_name": "VBoxModel",
           "state": {
             "_dom_classes": [
               "widget-interact"
@@ -826,10 +431,289 @@
             "layout": "IPY_MODEL_7da6ac50b3ba4eb080e018782434512d"
           }
         },
+        "1ce9a66df89441ad9e1fa31ac3c2cfaf": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "263ad9840616460aa4f070b0586c5dee": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "36f68f4e33c947b0992f896f76c3bec2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ButtonModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ButtonModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ButtonView",
+            "button_style": "",
+            "description": "Commit All Changes",
+            "disabled": false,
+            "icon": "",
+            "layout": "IPY_MODEL_c51787bb11a240c09d3acc563b23d959",
+            "style": "IPY_MODEL_9e35289d99c242a19a7a97c65ff8a2cd",
+            "tooltip": ""
+          }
+        },
+        "4381c6b7e415413c8660cb49b2032ae5": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "56755712d78b4e638af4e2f9729db622": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ButtonModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ButtonModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ButtonView",
+            "button_style": "",
+            "description": "Checkout Code",
+            "disabled": false,
+            "icon": "",
+            "layout": "IPY_MODEL_0e44d4863dea488d9b1bb4c55f0b31e0",
+            "style": "IPY_MODEL_7a150d899e224e0fabcf4566a17615c3",
+            "tooltip": ""
+          }
+        },
+        "5f4c433c39464ab996666c8fe41989df": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "TextModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "TextModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "TextView",
+            "continuous_update": true,
+            "description": "Branch name",
+            "description_tooltip": null,
+            "disabled": false,
+            "layout": "IPY_MODEL_263ad9840616460aa4f070b0586c5dee",
+            "placeholder": "Enter branch name",
+            "style": "IPY_MODEL_7793937dec9344919ae716c9d87ae5a7",
+            "value": "det"
+          }
+        },
+        "6eaa780782d64d4dbfe9ba4bb5b53de4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "VBoxModel",
+          "state": {
+            "_dom_classes": [
+              "widget-interact"
+            ],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "VBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "VBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_d689561e25ec4820bca22967363c2c9e",
+              "IPY_MODEL_5f4c433c39464ab996666c8fe41989df",
+              "IPY_MODEL_56755712d78b4e638af4e2f9729db622",
+              "IPY_MODEL_a481d46f789d4e1aa802b7461afa1114"
+            ],
+            "layout": "IPY_MODEL_a6ce23727bff4334be37cd86fa8acccd"
+          }
+        },
+        "7793937dec9344919ae716c9d87ae5a7": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "7a150d899e224e0fabcf4566a17615c3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ButtonStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ButtonStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "button_color": null,
+            "font_weight": ""
+          }
+        },
         "7adef417ce37401c98dfce5dee713327": {
           "model_module": "@jupyter-widgets/controls",
-          "model_name": "TextModel",
           "model_module_version": "1.5.0",
+          "model_name": "TextModel",
           "state": {
             "_dom_classes": [],
             "_model_module": "@jupyter-widgets/controls",
@@ -849,169 +733,10 @@
             "value": "required"
           }
         },
-        "36f68f4e33c947b0992f896f76c3bec2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ButtonModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ButtonModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ButtonView",
-            "button_style": "",
-            "description": "Commit All Changes",
-            "disabled": false,
-            "icon": "",
-            "layout": "IPY_MODEL_c51787bb11a240c09d3acc563b23d959",
-            "style": "IPY_MODEL_9e35289d99c242a19a7a97c65ff8a2cd",
-            "tooltip": ""
-          }
-        },
-        "b11d71f1b88243ff9515d54b3eea2495": {
-          "model_module": "@jupyter-widgets/output",
-          "model_name": "OutputModel",
-          "model_module_version": "1.0.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/output",
-            "_model_module_version": "1.0.0",
-            "_model_name": "OutputModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/output",
-            "_view_module_version": "1.0.0",
-            "_view_name": "OutputView",
-            "layout": "IPY_MODEL_a494def49c2e48a5be9f661f93f02876",
-            "msg_id": "",
-            "outputs": []
-          }
-        },
         "7da6ac50b3ba4eb080e018782434512d": {
           "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "fb7c2e7fca6c4599be40e40d398b55ac": {
-          "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "e3d728489ead4d29b0ddd4f58643deff": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "c51787bb11a240c09d3acc563b23d959": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
           "state": {
             "_model_module": "@jupyter-widgets/base",
             "_model_module_version": "1.2.0",
@@ -1062,8 +787,8 @@
         },
         "9e35289d99c242a19a7a97c65ff8a2cd": {
           "model_module": "@jupyter-widgets/controls",
-          "model_name": "ButtonStyleModel",
           "model_module_version": "1.5.0",
+          "model_name": "ButtonStyleModel",
           "state": {
             "_model_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
@@ -1076,10 +801,287 @@
             "font_weight": ""
           }
         },
+        "a481d46f789d4e1aa802b7461afa1114": {
+          "model_module": "@jupyter-widgets/output",
+          "model_module_version": "1.0.0",
+          "model_name": "OutputModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/output",
+            "_model_module_version": "1.0.0",
+            "_model_name": "OutputModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/output",
+            "_view_module_version": "1.0.0",
+            "_view_name": "OutputView",
+            "layout": "IPY_MODEL_4381c6b7e415413c8660cb49b2032ae5",
+            "msg_id": "",
+            "outputs": [
+              {
+                "name": "stdout",
+                "output_type": "stream",
+                "text": [
+                  "executing checkout_branch det...\n",
+                  "Branch det already checked out.\n",
+                  "Remember to reload your imports with `importlib.reload(module)`.\n",
+                  "b\"fatal: destination path 'ddf_common' already exists and is not an empty directory.\\nRepository already exists.\\n\"\n"
+                ]
+              },
+              {
+                "name": "stdout",
+                "output_type": "stream",
+                "text": [
+                  "b'From https://github.com/tnc-br/ddf_common\\n   6669160..533fd47  det        -> origin/det\\nUpdating 6669160..533fd47\\nFast-forward\\n model.py | 2 +-\\n 1 file changed, 1 insertion(+), 1 deletion(-)\\n'\n",
+                  "b''\n",
+                  "det branch checked out at \"/content/gdrive/MyDrive/det/ddf_common\". You may now use ddf_common imports and change common files.\n"
+                ]
+              },
+              {
+                "data": {
+                  "application/vnd.jupyter.widget-view+json": {
+                    "model_id": "15e0e911376547d892fc4677f5c4eb73",
+                    "version_major": 2,
+                    "version_minor": 0
+                  },
+                  "text/plain": "interactive(children=(Text(value='required', description='Commit Msg', placeholder='Enter commit message'), Bu…"
+                },
+                "metadata": {},
+                "output_type": "display_data"
+              }
+            ]
+          }
+        },
         "a494def49c2e48a5be9f661f93f02876": {
           "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "a6ce23727bff4334be37cd86fa8acccd": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b11d71f1b88243ff9515d54b3eea2495": {
+          "model_module": "@jupyter-widgets/output",
+          "model_module_version": "1.0.0",
+          "model_name": "OutputModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/output",
+            "_model_module_version": "1.0.0",
+            "_model_name": "OutputModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/output",
+            "_view_module_version": "1.0.0",
+            "_view_name": "OutputView",
+            "layout": "IPY_MODEL_a494def49c2e48a5be9f661f93f02876",
+            "msg_id": "",
+            "outputs": []
+          }
+        },
+        "c51787bb11a240c09d3acc563b23d959": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "d689561e25ec4820bca22967363c2c9e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "TextModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "TextModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "TextView",
+            "continuous_update": true,
+            "description": "Email",
+            "description_tooltip": null,
+            "disabled": false,
+            "layout": "IPY_MODEL_1ce9a66df89441ad9e1fa31ac3c2cfaf",
+            "placeholder": "Enter email",
+            "style": "IPY_MODEL_f6bdb0823b9743ad8b38d049629d390c",
+            "value": "tripiace@yahoo.com"
+          }
+        },
+        "e3d728489ead4d29b0ddd4f58643deff": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "f6bdb0823b9743ad8b38d049629d390c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "fb7c2e7fca6c4599be40e40d398b55ac": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
           "state": {
             "_model_module": "@jupyter-widgets/base",
             "_model_module_version": "1.2.0",

--- a/test_ee_raster.ipynb
+++ b/test_ee_raster.ipynb
@@ -1,22 +1,32 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "view-in-github"
+        "id": "view-in-github",
+        "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/eerasters/test_ee_raster.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/eedem/test_ee_raster.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xV--VZujfe62"
-      },
-      "outputs": [],
       "source": [
         "import sys\n",
         "!if [ ! -d \"/content/ddf_common_stub\" ] ; then git clone -b test https://github.com/tnc-br/ddf_common_stub.git; fi\n",
@@ -24,15 +34,15 @@
         "import ddfimport\n",
         "ddfimport.ddf_source_control_pane()\n",
         "# ddfimport.ddf_import_common()\n"
-      ]
+      ],
+      "metadata": {
+        "id": "xV--VZujfe62"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 115,
-      "metadata": {
-        "id": "etV5uhKRrNQ8"
-      },
-      "outputs": [],
       "source": [
         "import importlib\n",
         "import eeddf\n",
@@ -54,11 +64,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Nbn5shXqhge-"
-      },
-      "outputs": [],
       "source": [
         "# Brazil national territory extends 4,395 kilometers (2,731 mi) from north to\n",
         "# south (5°16'20\" N to 33°44'32\" S latitude), and 4,319 kilometers (2,684 mi)\n",
@@ -133,15 +138,15 @@
         "ee_performance()\n",
         "reference_sample_feature_test()\n",
         "performance_xtreme_test()\n"
-      ]
+      ],
+      "metadata": {
+        "id": "Nbn5shXqhge-"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "9vhNVeNRGnej"
-      },
-      "outputs": [],
       "source": [
         "# Brazil national territory extends 4,395 kilometers (2,731 mi) from north to\n",
         "# south (5°16'20\" N to 33°44'32\" S latitude), and 4,319 kilometers (2,684 mi)\n",
@@ -230,22 +235,12 @@
         "\n",
         "test_ingestion()\n",
         "test_stamped()"
-      ]
+      ],
+      "metadata": {
+        "id": "9vhNVeNRGnej"
+      },
+      "execution_count": null,
+      "outputs": []
     }
-  ],
-  "metadata": {
-    "colab": {
-      "include_colab_link": true,
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/test_ee_raster.ipynb
+++ b/test_ee_raster.ipynb
@@ -22,7 +22,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/eedem/test_ee_raster.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/main/test_ee_raster.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/test_ee_raster.ipynb
+++ b/test_ee_raster.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/ee_stamp/test_ee_raster.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -27,6 +12,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xV--VZujfe62"
+      },
+      "outputs": [],
       "source": [
         "import sys\n",
         "!if [ ! -d \"/content/ddf_common_stub\" ] ; then git clone -b test https://github.com/tnc-br/ddf_common_stub.git; fi\n",
@@ -34,15 +24,15 @@
         "import ddfimport\n",
         "ddfimport.ddf_source_control_pane()\n",
         "# ddfimport.ddf_import_common()\n"
-      ],
-      "metadata": {
-        "id": "xV--VZujfe62"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 115,
+      "metadata": {
+        "id": "etV5uhKRrNQ8"
+      },
+      "outputs": [],
       "source": [
         "import importlib\n",
         "import eeddf\n",
@@ -55,15 +45,15 @@
         "importlib.reload(dataset)\n",
         "import numpy as np\n",
         "import time"
-      ],
-      "metadata": {
-        "id": "etV5uhKRrNQ8"
-      },
-      "execution_count": 115,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Nbn5shXqhge-"
+      },
+      "outputs": [],
       "source": [
         "# Brazil national territory extends 4,395 kilometers (2,731 mi) from north to\n",
         "# south (5°16'20\" N to 33°44'32\" S latitude), and 4,319 kilometers (2,684 mi)\n",
@@ -138,15 +128,15 @@
         "ee_performance()\n",
         "reference_sample_feature_test()\n",
         "performance_xtreme_test()\n"
-      ],
-      "metadata": {
-        "id": "Nbn5shXqhge-"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "9vhNVeNRGnej"
+      },
+      "outputs": [],
       "source": [
         "def test_ingestion():\n",
         "    isoscape_path = raster.get_raster_path(\"test_isoscape.tiff\")\n",
@@ -161,12 +151,22 @@
         "\n",
         "test_ingestion()\n",
         "test_stamped()"
-      ],
-      "metadata": {
-        "id": "9vhNVeNRGnej"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
To prepare for generating rasters using EE, refactor file structure and move isoscape generation to dedicated file. I noticed eeraster.py depends on raster.py, so housing isoscape generation in raster.py creates a circular dependency.

Also implement a new function, dispatch_rasters, to decide whether to use ee or local files for sourcing rasters.