### PR TITLE
Updated for PRD ddf_common

### DIFF
--- a/ddf_ee_api.ipynb
+++ b/ddf_ee_api.ipynb
@@ -22,7 +22,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/ddf_ee_api/ddf_ee_api.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf_common/blob/simpifly_stub/ddf_ee_api.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -63,20 +63,14 @@
       "source": [
         "# This stub (ddfimport) allows the Ddf EE API to be imported.\n",
         "import sys\n",
-        "!if [ ! -d \"/content/ddf_common_stub\" ] ; then git clone -b test https://github.com/tnc-br/ddf_common_stub.git; fi\n",
+        "!if [ ! -d \"/content/ddf_common_stub\" ] ; then git clone -b main https://github.com/tnc-br/ddf_common_stub.git; fi\n",
         "sys.path.append(\"/content/ddf_common_stub/\")\n",
         "import ddfimport\n",
         "\n",
-        "# Use this line to import from a branch of the github repository.\n",
-        "# It will git clone the git repository under a google drive path.\n",
-        "# This allows you to modify the source files by opening the file view and\n",
-        "# changing files under /content/gdrive/MyDrive/<branch_name>\n",
-        "# ddfimport.ddf_source_control_pane()\n",
-        "\n",
-        "# Alternatively, you can use this line to import from Main.\n",
-        "# If you import from Main, you will not be able to change files, but will not\n",
-        "# need a Google Login for Google Drive.\n",
-        "ddfimport.ddf_import_common()\n"
+        "# The following line imports the DDF API from the production branch\n",
+        "# If you want a different branch, you may use the interactive UI and specify\n",
+        "# a different branch.\n",
+        "ddfimport.ddf_import_common()"
       ],
       "metadata": {
         "id": "xV--VZujfe62"
@@ -87,7 +81,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "If you chose 'ddf_source_control_pane' above, you will see that it prompted for an email and branch and prompted for a google login.  Once it has been cloned, another dialog shows for performing a `git commit`. You do not need to perform that step until you have made changes.\n",
+        "If you chose to specify a branch name and email above, you will see that it  prompted for a google login.  Once it has been cloned, another dialog shows for performing a `git commit`. You do not need to perform that step until you have made changes.\n",
         "\n",
         "You should be able to see source code by opening the colab folder view and navigating to /content/gdrive/MyDrive/branch_name. Here you may double click .py libraries and edit them within your colab.  \n",
         "\n",
@@ -106,6 +100,8 @@
         "\n",
         "# Its important to reload the module only if you make local changes to it.\n",
         "# If you make changes to other modules, they should similarly be reloaded here.\n",
+        "# This line should show the path /tmp/ddf_copmmon/eeddf.py when it loads from\n",
+        "# the production (default) branch.\n",
         "importlib.reload(eeddf)\n"
       ],
       "metadata": {
@@ -137,7 +133,7 @@
       "metadata": {
         "id": "3hFJbIDgv23B"
       },
-      "execution_count": 35,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -207,7 +203,7 @@
         },
         "outputId": "25157e88-2c28-44be-e3c1-31ef158b7535"
       },
-      "execution_count": 37,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",


### PR DESCRIPTION
This shows the updated method of using ddf_common, which aleways uses the ddfimport.ddf_import_common() API.

note that this api has two arguments (email and branch) if left blank uses the PRD branch of ddf_common.
Also if left blank, the API shows UI that allows you to select a different branch.
