### PR TITLE
Fix timestamp, allow duplicate training ids with different training runs

### DIFF
--- a/bqddf.py
+++ b/bqddf.py
@@ -2,6 +2,7 @@ import typing
 import google
 import json
 import eeddf
+import datetime
 from google.cloud import bigquery
 from google.api_core.exceptions import GoogleAPIError
 
@@ -56,6 +57,7 @@ def _insert_eval_metadata(metadata: typing.Dict[str, typing.Any]) -> typing.List
   # Set up reference to table we write to.
   table_ref = client.dataset(_CONFIG['DATASET']).table(_CONFIG['METADATA_TABLE'])
   job_config = bigquery.LoadJobConfig(write_disposition='WRITE_APPEND')
+  metadata['completion_timestamp'] = datetime.datetime.now().isoformat()
 
   # Write and block until complete.
   load_job = client.load_table_from_json(
@@ -146,6 +148,8 @@ def _insert_training_metadata(metadata: typing.Dict[str, typing.Any]) -> typing.
   table_ref = client.dataset(_CONFIG['DATASET']).table(_CONFIG['TRAINING_METADATA_TABLE'])
   job_config = bigquery.LoadJobConfig(write_disposition='WRITE_APPEND')
 
+  metadata['completion_timestamp'] = datetime.datetime.now().isoformat()
+
   # Write and block until complete.
   load_job = client.load_table_from_json(
     [metadata], table_ref, job_config=job_config)
@@ -209,6 +213,7 @@ def insert_harness_run(
 
   eval_results['eval_id'] = _generate_eval_id(eval_results)
   flattened = training_metadata | eval_results
+  flattened['completion_timestamp'] = datetime.datetime.now().isoformat()
 
   table_ref = client.dataset(_CONFIG['DATASET']).table(_CONFIG['FLATTENED_TABLE'])
   job_config = bigquery.LoadJobConfig(write_disposition='WRITE_APPEND')

--- a/bqddf.py
+++ b/bqddf.py
@@ -197,7 +197,8 @@ def get_training_result_from_flattened(training_id: str) -> bigquery.table.RowIt
 
 def insert_harness_run(
   training_metadata: typing.Dict[str, typing.Any],
-  eval_results: typing.Dict[str, typing.Any]):
+  eval_results: typing.Dict[str, typing.Any],
+  eval_only=False):
   """
   Writes training and eval results to flattened BQ table. 
   If the training_id already exists, don't overwrite it. 
@@ -207,7 +208,7 @@ def insert_harness_run(
 
   # Check if eval_id exists before writing it.
   exists = get_training_result_from_flattened(training_metadata['training_id']).total_rows
-  if exists:
+  if exists and not eval_only:
     raise GoogleAPIError(f"training_id {training_metadata['training_id']} already exists. " +
                           "A training with these params has already run.")
 

--- a/bqddf.py
+++ b/bqddf.py
@@ -191,8 +191,6 @@ def get_training_result_from_flattened(training_id: str) -> bigquery.table.RowIt
 
   # Execute the query
   results = client.query_and_wait(query)
-  if results.total_rows > 1:
-    return ReferenceError(f"Two or more trainings found for training_id {training_id}")
   return results
 
 def insert_harness_run(

--- a/train_variational_inference_model.py
+++ b/train_variational_inference_model.py
@@ -239,7 +239,7 @@ def train_variational_inference_model(
     eval_metadata = eval_params.convert_to_bq_dict()
     eval_metadata |= eval_results.convert_to_bq_dict()
 
-    bqddf.insert_harness_run(training_run, eval_metadata)
+    bqddf.insert_harness_run(training_run, eval_metadata, eval_only)
         
     return eval_results
     


### PR DESCRIPTION
1) Fix a timestamp bug caused by load_json (see https://stackoverflow.com/questions/75730788/bigquery-load-does-not-produce-default-values-when-importing-json)
2) Allow the same training id to be written twice as long as eval_only is true. Note, this does not prevent the user from modifying training params and using it to write a new different row. 